### PR TITLE
Standardize department names and update news events API calls

### DIFF
--- a/src/app/authorities/offices/[id]/page.tsx
+++ b/src/app/authorities/offices/[id]/page.tsx
@@ -1,29 +1,29 @@
-import React from 'react';
+import React from "react";
 
-import PageHeader from '@/components/page-header';
-import { getOfficeEntry, getOffices } from '@/server/get';
-import Content from './_components/content';
+import PageHeader from "@/components/page-header";
+import { getOfficeEntry, getOffices } from "@/server/get";
+import Content from "./_components/content";
 
 export default async function Page({
-  params,
+	params,
 }: {
-  params: Promise<{
-    id: string;
-  }>;
+	params: Promise<{
+		id: string;
+	}>;
 }) {
-  const { id } = await params;
-  const data = await getOfficeEntry(id);
-  const listOfOffices = await getOffices();
-  const title = listOfOffices?.find((item) => item.category === id)?.title;
-
-  return (
-    <>
-      <PageHeader title={title || 'Office Details'} />
-      <Content
-        data={data || []}
-        listOfOffices={listOfOffices || []}
-        category={title || ''}
-      />
-    </>
-  );
+	const { id } = await params;
+	const data = await getOfficeEntry(id);
+	const listOfOffices = await getOffices();
+	const title = listOfOffices?.find((item) => item.category === id)?.title;
+	
+	return (
+		<>
+			<PageHeader title={title || "Office Details"} />
+			<Content
+				data={data || []}
+				listOfOffices={listOfOffices || []}
+				category={title || ""}
+			/>
+		</>
+	);
 }

--- a/src/app/programs/school-of-arts-and-social-sciences/ba-english/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/ba-english/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BA-ENGLISH' />;
+	return <NewsAndEvents department="ba-english" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-arts-and-social-sciences/bss-economics/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/bss-economics/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BSS-ECONOMICS' />;
+	return <NewsAndEvents department="bss-economics" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-arts-and-social-sciences/llb/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/llb/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='LLB' />;
+	return <NewsAndEvents department="llb" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-arts-and-social-sciences/llm/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/llm/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='LLM' />;
+	return <NewsAndEvents department="llm" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-arts-and-social-sciences/ma-english/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/ma-english/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='MA-ENGLISH' />;
+	return <NewsAndEvents department="ma-english" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-arts-and-social-sciences/mgds-one-year/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/mgds-one-year/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='MGDS-ONE-YEAR' />;
+	return <NewsAndEvents department="mgds-one-year" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-arts-and-social-sciences/mss-economics/_components/news-events.tsx
+++ b/src/app/programs/school-of-arts-and-social-sciences/mss-economics/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='MSS-ECONOMICS' />;
+	return <NewsAndEvents department="mss-economics" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-business-administration/bba/_components/news-events.tsx
+++ b/src/app/programs/school-of-business-administration/bba/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BBA' />;
+	return <NewsAndEvents department="bba" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-business-administration/emba/_components/news-events.tsx
+++ b/src/app/programs/school-of-business-administration/emba/_components/news-events.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import NewsAndEvents from '@/app/programs/_components/news-and-events';
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='EMBA' />;
+  return <NewsAndEvents department="emba" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-business-administration/mba-one-year/_components/news-events.tsx
+++ b/src/app/programs/school-of-business-administration/mba-one-year/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='MBA-ONE-YEAR' />;
+	return <NewsAndEvents department="mba-one-year" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-business-administration/mba/_components/news-events.tsx
+++ b/src/app/programs/school-of-business-administration/mba/_components/news-events.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import NewsAndEvents from '@/app/programs/_components/news-and-events';
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='MBA' />;
+  return <NewsAndEvents department="mba" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-business-administration/thm/_components/news-events.tsx
+++ b/src/app/programs/school-of-business-administration/thm/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='THM' />;
+	return <NewsAndEvents department="thm" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-science-engineering/bsc-civil/_components/news-events.tsx
+++ b/src/app/programs/school-of-science-engineering/bsc-civil/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BSC-CIVIL' />;
+	return <NewsAndEvents department="bsc-civil" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-science-engineering/bsc-computer-science/_components/news-events.tsx
+++ b/src/app/programs/school-of-science-engineering/bsc-computer-science/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='CSE' />;
+	return <NewsAndEvents department="bsc-cse" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-science-engineering/bsc-electrical-and-electronics/_components/news-events.tsx
+++ b/src/app/programs/school-of-science-engineering/bsc-electrical-and-electronics/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BSC-EEE' />;
+	return <NewsAndEvents department="bsc-eee" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-science-engineering/bsc-industrial-and-production/_components/news-events.tsx
+++ b/src/app/programs/school-of-science-engineering/bsc-industrial-and-production/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BSC-IP' />;
+	return <NewsAndEvents department="bsc-ip" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/school-of-science-engineering/bsc-mechanical/_components/core-faculty-members.tsx
+++ b/src/app/programs/school-of-science-engineering/bsc-mechanical/_components/core-faculty-members.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import FacultyAndStaff from '@/app/programs/_components/faculty-and-staff';
+import FacultyAndStaff from "@/app/programs/_components/faculty-and-staff";
 
 const CoreFacultyMembers = () => {
-  return <FacultyAndStaff department='BSC-MECHANICAL' />;
+	return <FacultyAndStaff department="bsc-mechanical" />;
 };
 
 export default CoreFacultyMembers;

--- a/src/app/programs/school-of-science-engineering/bsc-textile/_components/news-events.tsx
+++ b/src/app/programs/school-of-science-engineering/bsc-textile/_components/news-events.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import NewsAndEvents from '@/app/programs/_components/news-and-events';
+import NewsAndEvents from "@/app/programs/_components/news-and-events";
+import React from "react";
 
 const NewsEvents = () => {
-  return <NewsAndEvents department='BSC-TEXTILE' />;
+	return <NewsAndEvents department="bsc-textile" />;
 };
 
 export default NewsEvents;

--- a/src/server/get/get-news-events.ts
+++ b/src/server/get/get-news-events.ts
@@ -1,13 +1,13 @@
-'use server';
+"use server";
 
-import fetchApi from '@/utils/fetchApi';
-import { INewsPortal, IPaginationResponse } from '@/types';
+import { INewsPortal, IPaginationResponse } from "@/types";
+import fetchApi from "@/utils/fetchApi";
 
 export const getNewsEvents = async (
-  limit: number = 10,
-  page: number = 1
+	limit: number = 10,
+	page: number = 1
 ): Promise<IPaginationResponse<INewsPortal>> =>
-  fetchApi(`/portfolio/news?limit=${limit}&page=${page}`);
+	fetchApi(`/portfolio/news?limit=${limit}&page=${page}&is_global=true`);
 
 export const getNewsById = async (id: string): Promise<INewsPortal> =>
-  fetchApi(`/portfolio/news/${id}`);
+	fetchApi(`/portfolio/news/${id}`);


### PR DESCRIPTION
Standardize department names to lowercase in the NewsEvents components and update fetch API calls to include the `is_global` parameter for news events.