### PR TITLE
Fix department notice and faculty display issues

### DIFF
--- a/src/app/(top-navbar)/publications/page.tsx
+++ b/src/app/(top-navbar)/publications/page.tsx
@@ -23,7 +23,7 @@ export default async function Page(props: {
   });
 
   const faculties = await getFaculties();
-
+console.log(data);
   return (
     <>
       <PageHeader

--- a/src/app/programs/(faculty-of-sciences)/chemistry/_components/core-faculty-members.tsx
+++ b/src/app/programs/(faculty-of-sciences)/chemistry/_components/core-faculty-members.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FacultyAndStaff from '@/app/programs/_components/faculty-and-staff';
 
 const CoreFacultyMembers = () => {
-  return <FacultyAndStaff department='BSC-CIVIL' />;
+  return <FacultyAndStaff department='Chemistry' />;
 };
 
 export default CoreFacultyMembers;

--- a/src/app/programs/(faculty-of-sciences)/chemistry/_components/news-events.tsx
+++ b/src/app/programs/(faculty-of-sciences)/chemistry/_components/news-events.tsx
@@ -2,7 +2,7 @@ import NewsAndEvents from "@/app/programs/_components/news-and-events";
 import React from "react";
 
 const NewsEvents = () => {
-	return <NewsAndEvents department="bsc-civil" />;
+	return <NewsAndEvents department="Chemistry" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/(faculty-of-sciences)/chemistry/_const/accordion-data.tsx
+++ b/src/app/programs/(faculty-of-sciences)/chemistry/_const/accordion-data.tsx
@@ -43,7 +43,7 @@ const accordions: IAcademicAccordion[] = [
   },
   {
     title: 'Notices',
-    content: <Notices department='BSC-CIVIL' />,
+    content: <Notices department='Chemistry' />,
   },
   {
     title: 'News & Events',

--- a/src/app/programs/(faculty-of-sciences)/mathematics/_components/core-faculty-members.tsx
+++ b/src/app/programs/(faculty-of-sciences)/mathematics/_components/core-faculty-members.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FacultyAndStaff from '@/app/programs/_components/faculty-and-staff';
 
 const CoreFacultyMembers = () => {
-  return <FacultyAndStaff department='BSC-CIVIL' />;
+  return <FacultyAndStaff department='Mathematics' />;
 };
 
 export default CoreFacultyMembers;

--- a/src/app/programs/(faculty-of-sciences)/mathematics/_components/news-events.tsx
+++ b/src/app/programs/(faculty-of-sciences)/mathematics/_components/news-events.tsx
@@ -2,7 +2,7 @@ import NewsAndEvents from "@/app/programs/_components/news-and-events";
 import React from "react";
 
 const NewsEvents = () => {
-	return <NewsAndEvents department="bsc-civil" />;
+	return <NewsAndEvents department="Mathematics" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/(faculty-of-sciences)/mathematics/_const/accordion-data.tsx
+++ b/src/app/programs/(faculty-of-sciences)/mathematics/_const/accordion-data.tsx
@@ -38,7 +38,7 @@ const accordions: IAcademicAccordion[] = [
   },
   {
     title: 'Notices',
-    content: <Notices department='BSC-CIVIL' />,
+    content: <Notices department='Mathematics' />,
   },
   {
     title: 'News & Events',

--- a/src/app/programs/(faculty-of-sciences)/physics/_components/core-faculty-members.tsx
+++ b/src/app/programs/(faculty-of-sciences)/physics/_components/core-faculty-members.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FacultyAndStaff from '@/app/programs/_components/faculty-and-staff';
 
 const CoreFacultyMembers = () => {
-  return <FacultyAndStaff department='BSC-CIVIL' />;
+  return <FacultyAndStaff department='Physics' />;
 };
 
 export default CoreFacultyMembers;

--- a/src/app/programs/(faculty-of-sciences)/physics/_components/news-events.tsx
+++ b/src/app/programs/(faculty-of-sciences)/physics/_components/news-events.tsx
@@ -2,7 +2,7 @@ import NewsAndEvents from "@/app/programs/_components/news-and-events";
 import React from "react";
 
 const NewsEvents = () => {
-	return <NewsAndEvents department="bsc-civil" />;
+	return <NewsAndEvents department="Physics" />;
 };
 
 export default NewsEvents;

--- a/src/app/programs/(faculty-of-sciences)/physics/_const/accordion-data.tsx
+++ b/src/app/programs/(faculty-of-sciences)/physics/_const/accordion-data.tsx
@@ -43,7 +43,7 @@ const accordions: IAcademicAccordion[] = [
   },
   {
     title: 'Notices',
-    content: <Notices department='BSC-CIVIL' />,
+    content: <Notices department='Physics' />,
   },
   {
     title: 'News & Events',


### PR DESCRIPTION
Update department references in the Faculty and Staff and News and Events components to ensure accurate display of information for Chemistry, Mathematics, and Physics. Additionally, address a bug related to department notices.